### PR TITLE
UPnP Fixed

### DIFF
--- a/src/NetworkTest/NetworkTest/NetworkTest.csproj
+++ b/src/NetworkTest/NetworkTest/NetworkTest.csproj
@@ -54,6 +54,9 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Open.Nat">
+      <HintPath>..\..\packages\Open.NAT.2.0.11.0\lib\net45\Open.Nat.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
@@ -105,6 +108,7 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <None Include="app.manifest" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/src/NetworkTest/NetworkTest/packages.config
+++ b/src/NetworkTest/NetworkTest/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Open.NAT" version="2.0.11.0" targetFramework="net45" />
+</packages>

--- a/src/P2CNetwork/P2CNetwork/NetworkServer.cs
+++ b/src/P2CNetwork/P2CNetwork/NetworkServer.cs
@@ -64,8 +64,9 @@ namespace Network
 		IPublicProfile userPublicProfile;
 		
 		const int recommendedPort = 15;					// this value has to be below 1024
-		const int NATPublicPort = 15;					// Assuming the average user is not using software that is listening on 80 (web server, IIS, skype, ect.)
-		int defaultPort;
+		int NATPublicPort;
+        int privatePort;
+        int defaultPort;                                // May need to declare this const and set it here, since it's default.
 		int backlog;
 
 		System.Windows.Controls.Control crossCommuniationHack;
@@ -90,7 +91,8 @@ namespace Network
 			friendsProfileDict		= new ConcurrentDictionary<Guid,IPublicProfile>();
 			friendsIPaddressDict	= new ConcurrentDictionary<Guid,IPEndPoint>();
 
-			defaultPort = port;	
+			NATPublicPort = port;
+            privatePort = port;
 			this.backlog = backlog;	
 		}
 
@@ -165,7 +167,9 @@ namespace Network
 											// create a new mapping in the router, external_ip:80 -> host_machine:defaultPort
 											// We are assuming advance user know what they are doing
 											// maybe in the future catch MappingException : http://www.codeproject.com/Articles/807861/Open-NAT-A-NAT-Traversal-library-for-NET-and-Mono
-											await natDevice.CreatePortMapAsync(new Mapping(Protocol.Tcp, defaultPort, NATPublicPort));										
+											
+                                            // 600 is the lifetime of the portmapping, this will need to be configurable in the future. If not for the user, for the ViewModel 
+                                            await natDevice.CreatePortMapAsync(new Mapping(Protocol.Tcp, privatePort, NATPublicPort, 600, "P2Crypt Portmapping"));										
 											isUpnpFeatureOn = true;
 
 											Task.Run(()=>

--- a/src/P2CNetwork/P2CNetwork/NetworkServer.cs
+++ b/src/P2CNetwork/P2CNetwork/NetworkServer.cs
@@ -34,7 +34,6 @@ using P2CCore;
 using System.IO;
 using P2CCommon;
 using System.Net.NetworkInformation;
-
 using Open.Nat;
 
 namespace Network 

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
+  <repository path="..\NetworkTest\NetworkTest\packages.config" />
   <repository path="..\P2CNetwork\P2CNetwork\packages.config" />
   <repository path="..\UiTest\UiTest\packages.config" />
 </repositories>


### PR DESCRIPTION
Changed the constructor to set privatePort and NATPublicPort. These should generally be the same port and are set as such. Also set the default port parameter to 6886 instead of 15, 15 won't work. 

If we catch the UPnP error 718 again, we should just try a different port, because this usually indicates a port is already forwarded on a NAT machine. The original error I was getting was because NATPublicPort was always set to Port 15, rather than being changed in the UI. 
